### PR TITLE
Create custom Kegberry Database Docker Image

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,7 @@
+FROM yobasystems/alpine-mariadb:latest
+
+RUN apk add tzdata
+COPY . /scripts
+RUN chmod -R 755 /scripts
+
+ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/scripts/init_tzdata.sh & /scripts/run.sh --innodb_file_format=Barracuda --innodb_default_row_format=DYNAMIC --innodb_large_prefix=ON

--- a/db/init_tzdata.sh
+++ b/db/init_tzdata.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Wait to be sure that MySql is up
+while ! /usr/bin/mysql -u root -e "use mysql;"
+do
+    sleep 2
+done
+
+echo "APPLY SYSTEM TIMEZONES START"
+
+query="select count(*) from time_zone"
+
+count=`/usr/bin/mysql -u root --skip-column-names mysql << eof
+$query
+eof`
+
+if [ $count -eq 0 ]
+then
+    sh -c "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql"
+    echo "APPLY SYSTEM TIMEZONES COMPLETE"
+else
+    echo "SYSTEM TIMEZONES ALREAY POPULATED"
+fi

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ services:
       KEGBOT_SECRET_KEY: '_kegbot_secret_key_'
 
   mysql:
-    image: yobasystems/alpine-mariadb:latest
+    image: jruzia/kegberry-mariadb:latest
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: 'changeme'
@@ -54,7 +54,7 @@ services:
       - /var/tmp
     volumes:
       - _mysql_data_dir_:/var/lib/mysql
-    entrypoint: /scripts/run.sh --innodb_file_format=Barracuda --innodb_default_row_format=DYNAMIC --innodb_large_prefix=ON
+    entrypoint: /scripts/entrypoint.sh
 
   redis:
     image: redis:latest


### PR DESCRIPTION
This is initial work to great a custom Kegberry MariaDB SQL image. The base image from yobasystems works great but does not have the timezone tables populated which causes issues with the "Sessions" page in the applicaiton.

This Dockerfile uses the yobasystems image as base, but then adds the tzdata package to the image and executes a second script at startup that will wait for MySQL to be ready to accept connections, and then apply the time zone info settings if the table is empty.

Right now the docker-compose template is referencing my Docker-Hub image, but should be updated to point to kegbot/kegberry-mariadb once it looks good and the image is build and published to that repository.

Very much open to suggestions for making this process better!